### PR TITLE
Update about.hbs

### DIFF
--- a/src/partials/about.hbs
+++ b/src/partials/about.hbs
@@ -10,7 +10,7 @@
     <h4>Search datasets (currently <span id="count-matching">13</span> matching <span id="count-matching-text">datasets</span>)</h4>
     <form>
       <div class="form-group">
-        <input type="text" id="search-box" class="form-control" placeholder="Search datasets">
+        <input type="text" id="search-box" class="form-control" placeholder="Search datasets" spellcheck="false" autocorrect="off">
       </div>
     </form>
 


### PR DESCRIPTION
Adding 'spellcheck="false"' and 'autocorrect="off"' to input field to make searching for weird terms easier. FWIW, autocorrect is a Safari-only attribute.