### PR TITLE
Re-arrange parameters to aws s3 ls CLI example

### DIFF
--- a/src/detail.hbs
+++ b/src/detail.hbs
@@ -96,7 +96,7 @@
             {{#isEqual Type 'S3 Bucket'}}
             {{#unless ControlledAccess}}
             <dt class="resource-region"><a href="https://aws.amazon.com/cli/">AWS CLI</a> Access{{#unless RequesterPays}} (No AWS account required){{/unless}}</dt>
-            <dd><code>aws s3 ls s3://{{{arnToBucket ARN}}} {{{regionToFlag Region}}}{{#if RequesterPays}}--request-payer requester{{else}}--no-sign-request{{/if}}</code></dd>
+            <dd><code>aws s3 ls {{{regionToFlag Region}}}{{#if RequesterPays}}--request-payer requester{{else}}--no-sign-request{{/if}} s3://{{{arnToBucket ARN}}}</code></dd>
             {{/unless}}
             {{/isEqual}}
             {{#if Explore}}

--- a/tests/test-data-compare/usgs-landsat.html
+++ b/tests/test-data-compare/usgs-landsat.html
@@ -131,7 +131,7 @@ when citing, copying, or reprinting USGS Landsat data or images.</p>
             <dt class="resource-region">AWS Region</dt>
             <dd><code>us-west-2</code></dd>
             <dt class="resource-region"><a href="https://aws.amazon.com/cli/">AWS CLI</a> Access</dt>
-            <dd><code>aws s3 ls s3://usgs-landsat/collection02/ --request-payer requester</code></dd>
+            <dd><code>aws s3 ls --request-payer requester s3://usgs-landsat/collection02/</code></dd>
             <dt class="resource-explore">Explore</dt>
             <dd><a href="https://landsatlook.usgs.gov/sat-api/collections">STAC Catalog</a></dd>
           </dl>


### PR DESCRIPTION
*Issue #, if available:* (unfiled)

*Description of changes:*

This change takes the `--region` and `--requester-payer` or `--no-sign-request` arguments and moves them before the S3 bucket.

Often when copying and pasting the CLI example, I need to navigate further into the bucket and my poor left arrow key is starting to show weakness. Please consider swapping the order of the arguments and save the left arrow keys of the world. :)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
